### PR TITLE
update matchPackage regex to fix bug that matches import statements in comments

### DIFF
--- a/src/go-imports-search.ts
+++ b/src/go-imports-search.ts
@@ -13,7 +13,7 @@ export function activate(): void {
                     pkgFilter && pkgFilter.length >= 1 ? pkgFilter[1] : '';
 
                 // Package imported in grouped import statements
-                const matchPackage = '\\t"[^\\s]*' + pkg + '[^\\s]*"$';
+                const matchPackage = '^\\t"[^\\s]*' + pkg + '[^\\s]*"$';
                 // Match packages with aliases
                 const matchAlias = '\\t[\\w/]*\\s"[^\\s]*' + pkg + '[^\\s]*"$';
                 // Match packages in single import statement


### PR DESCRIPTION
I believe this fix has already been published by someone else (from the thread https://sourcegraph.slack.com/archives/CHXHX7XAS/p1568230226074500), but the code does not seem to have been updated yet.